### PR TITLE
Change RxAndroid dependency to RxJava

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Heimdall is an [OAuth 2.0](https://tools.ietf.org/html/rfc6749) client specifically designed for easy usage and high flexibility. It supports all grants as described in [Section 4](https://tools.ietf.org/html/rfc6749#section-4) as well as refreshing an access token as described in [Section 6](https://tools.ietf.org/html/rfc6749#section-6) of the [The OAuth 2.0 Authorization Framework](https://tools.ietf.org/html/rfc6749) specification.
 
-This library makes use of [RxAndroid](https://github.com/ReactiveX/RxAndroid). Therefore you should be familar with [Observables](https://github.com/ReactiveX/RxJava/wiki/Observable).
+This library makes use of [RxJava](https://github.com/ReactiveX/RxJava). Therefore you should be familar with [Observables](https://github.com/ReactiveX/RxJava/wiki/Observable).
 
 If you are an iOS Developer then please take a look at the [Swift version of Heimdall](https://github.com/rheinfabrik/Heimdall.swift).
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -57,7 +57,7 @@ repositories {
 dependencies {
 
     // Rx
-    compile 'io.reactivex:rxandroid-framework:0.24.0'
+    compile 'io.reactivex:rxjava:1.0.12'
 
     // GSON
     compile 'com.google.code.gson:gson:2.3.1'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -40,6 +40,9 @@ dependencies {
     // Heimdall
     compile project(':library')
 
+    // Rx
+    compile 'io.reactivex:rxandroid-framework:0.24.0'
+
     // Serialization
     compile 'com.google.code.gson:gson:2.3'
     compile 'org.parceler:parceler-api:0.2.16'


### PR DESCRIPTION
Since the library itself doesn't use any RxAndroid-specific stuff I switched the dependency.