### PR TITLE
Fix #31 - Lower minSDK

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -35,10 +35,10 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 8
         targetSdkVersion 22
-        versionCode 101
-        versionName "1.0.1"
+        versionCode 102
+        versionName "1.0.2"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
@@ -64,7 +64,7 @@ dependencies {
 
     // Spock
     androidTestCompile 'org.codehaus.groovy:groovy:2.4.2:grooid'
-    androidTestCompile "com.andrewreitz:spock-android:1.2.0"
+    androidTestCompile "com.andrewreitz:spock-android:1.2.1"
     androidTestCompile 'com.android.support.test:testing-support-lib:0.1'
     androidTestCompile('org.spockframework:spock-core:1.0-groovy-2.4') {
         exclude group: 'org.codehaus.groovy'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -35,7 +35,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 8
+        minSdkVersion 9
         targetSdkVersion 22
         versionCode 101
         versionName "1.0.1"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -37,8 +37,8 @@ android {
     defaultConfig {
         minSdkVersion 8
         targetSdkVersion 22
-        versionCode 102
-        versionName "1.0.2"
+        versionCode 101
+        versionName "1.0.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
This aims to answer question asked in #31 - If that is not the case, feel free to close this `PR` without merging.
Changes here include:
- Update android-spock to latest. This allows us to support minSDK 8 and above
- Lowered to minSDK to 8
- ~~Bump version number~~