### PR TITLE
Add coroutines support - Part II

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'maven'
 
 buildscript {
     ext.kotlin_version = '1.4.10'
+    ext.kotlin_coroutines = '1.3.9'
 
     repositories {
         mavenCentral()
@@ -34,14 +35,14 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.6'
 
     // Coroutines
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlin_coroutines"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlin_coroutines"
 
     // Testing
     testImplementation 'junit:junit:4.13'
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
     testImplementation "org.mockito:mockito-inline:3.5.11"
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.9"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlin_coroutines"
 }
 
 compileKotlin {

--- a/library/src/main/java/de/rheinfabrik/heimdall2/coroutines/OAuth2AccessTokenManager.kt
+++ b/library/src/main/java/de/rheinfabrik/heimdall2/coroutines/OAuth2AccessTokenManager.kt
@@ -1,0 +1,72 @@
+package de.rheinfabrik.heimdall2.coroutines
+
+import de.rheinfabrik.heimdall2.accesstoken.OAuth2AccessToken
+import de.rheinfabrik.heimdall2.coroutines.grants.OAuth2Grant
+import de.rheinfabrik.heimdall2.coroutines.grants.OAuth2RefreshAccessTokenGrant
+import java.util.Calendar
+
+open class OAuth2AccessTokenManager(
+    private val mOAuth2AccessTokenStorage: OAuth2AccessTokenStorage
+) {
+
+    // Public API
+
+    /**
+     * Returns the underlying storage.
+     *
+     * @return - An OAuth2AccessTokenStorage.
+     */
+    fun getStorage(): OAuth2AccessTokenStorage = mOAuth2AccessTokenStorage
+
+    /**
+     * Grants a new access token using the given OAuth2 grant.
+     *
+     * @param grant A class implementing the OAuth2Grant interface.
+     * @return - A granted access token.
+     */
+    suspend fun grantNewAccessToken(
+        grant: OAuth2Grant,
+        calendar: Calendar = Calendar.getInstance()
+    ): OAuth2AccessToken {
+        val token = grant.grantNewAccessToken()
+        val updatedToken = if (token.expiresIn != null) {
+            val newExpirationDate = (calendar.clone() as Calendar).apply {
+                add(Calendar.SECOND, token.expiresIn)
+            }
+            token.copy(
+                expirationDate = newExpirationDate
+            )
+        } else {
+            token
+        }
+
+        mOAuth2AccessTokenStorage.storeAccessToken(
+            token = updatedToken
+        )
+        return updatedToken
+    }
+
+    /**
+     * Returns an unexpired access token.
+     * NOTE: In order to work, Heimdall needs an access token which has a refresh_token and an
+     * expires_in field.
+     *
+     * @param refreshAccessTokenGrant The refresh grant that will be used if the access token is expired.
+     * @return - An unexpired access token.
+     */
+    suspend fun getValidAccessToken(
+        refreshAccessTokenGrant: OAuth2RefreshAccessTokenGrant
+    ): OAuth2AccessToken {
+        val storedAccessToken = mOAuth2AccessTokenStorage.getStoredAccessToken()
+        return if (storedAccessToken.isExpired()) {
+            storedAccessToken.refreshToken?.let { refreshToken ->
+                refreshAccessTokenGrant.refreshToken = refreshToken
+                    grantNewAccessToken(
+                        grant = refreshAccessTokenGrant
+                    )
+            } ?: throw IllegalStateException("Refresh Token for Refresh Access Token Grant is required")
+        } else {
+            storedAccessToken
+        }
+    }
+}

--- a/library/src/main/java/de/rheinfabrik/heimdall2/coroutines/OAuth2AccessTokenStorage.kt
+++ b/library/src/main/java/de/rheinfabrik/heimdall2/coroutines/OAuth2AccessTokenStorage.kt
@@ -1,0 +1,39 @@
+package de.rheinfabrik.heimdall2.coroutines
+
+import de.rheinfabrik.heimdall2.accesstoken.OAuth2AccessToken
+
+/**
+ * Interface used to define how to store and retrieve a stored access token.
+ *
+ * @param <TAccessToken> The access token type.
+ */
+interface OAuth2AccessTokenStorage {
+    // Public API
+
+    /**
+     * Queries the stored access token.
+     *
+     * @return - An Observable emitting the stored access token.
+     */
+    suspend fun getStoredAccessToken(): OAuth2AccessToken
+
+    /**
+     * Stores the given access token.
+     *
+     * @param token The access token which will be stored.
+     */
+    suspend fun storeAccessToken(token: OAuth2AccessToken)
+
+    /**
+     * Checks whether there is or is not an access token
+     *
+     * @return - An Observable emitting true or false based on whether there is or is not an
+     * access token.
+     */
+    suspend fun hasAccessToken(): Boolean
+
+    /**
+     * Removes the stored access token.
+     */
+    suspend fun removeAccessToken()
+}

--- a/library/src/main/java/de/rheinfabrik/heimdall2/coroutines/OAuth2AccessTokenStorage.kt
+++ b/library/src/main/java/de/rheinfabrik/heimdall2/coroutines/OAuth2AccessTokenStorage.kt
@@ -13,7 +13,7 @@ interface OAuth2AccessTokenStorage {
     /**
      * Queries the stored access token.
      *
-     * @return - An Observable emitting the stored access token.
+     * @return - The stored access token.
      */
     suspend fun getStoredAccessToken(): OAuth2AccessToken
 
@@ -27,8 +27,7 @@ interface OAuth2AccessTokenStorage {
     /**
      * Checks whether there is or is not an access token
      *
-     * @return - An Observable emitting true or false based on whether there is or is not an
-     * access token.
+     * @return - True or false based on whether there is or is not an access token.
      */
     suspend fun hasAccessToken(): Boolean
 

--- a/library/src/main/java/de/rheinfabrik/heimdall2/coroutines/grants/OAuth2ClientCredentialsGrant.kt
+++ b/library/src/main/java/de/rheinfabrik/heimdall2/coroutines/grants/OAuth2ClientCredentialsGrant.kt
@@ -1,0 +1,21 @@
+package de.rheinfabrik.heimdall2.coroutines.grants
+
+abstract class OAuth2ClientCredentialsGrant(
+    /**
+     * OPTIONAL
+     * The scope of the access request as described in https://tools.ietf.org/html/rfc6749#section-3.3.
+     */
+    val scope: String? = null
+) : OAuth2Grant {
+
+    // Constants
+
+    companion object {
+        /**
+         * REQUIRED
+         * The OAuth2 "grant_type".
+         */
+        @JvmField
+        val GRANT_TYPE = "client_credentials"
+    }
+}

--- a/library/src/main/java/de/rheinfabrik/heimdall2/coroutines/grants/OAuth2Grant.kt
+++ b/library/src/main/java/de/rheinfabrik/heimdall2/coroutines/grants/OAuth2Grant.kt
@@ -1,0 +1,20 @@
+package de.rheinfabrik.heimdall2.coroutines.grants
+
+import de.rheinfabrik.heimdall2.accesstoken.OAuth2AccessToken
+
+/**
+ * Interface describing an OAuth2 Grant as described in https://tools.ietf.org/html/rfc6749#page-23.
+ *
+ * @param <TAccessToken> The access token type.
+ */
+interface OAuth2Grant {
+
+    // Abstract Api
+
+    /**
+     * Performs the actual request to grant a new access token.
+     *
+     * @return - The granted access token.
+     */
+    suspend fun grantNewAccessToken(): OAuth2AccessToken
+}

--- a/library/src/main/java/de/rheinfabrik/heimdall2/coroutines/grants/OAuth2ImplicitGrant.kt
+++ b/library/src/main/java/de/rheinfabrik/heimdall2/coroutines/grants/OAuth2ImplicitGrant.kt
@@ -1,0 +1,50 @@
+package de.rheinfabrik.heimdall2.coroutines.grants
+
+/**
+ * Class representing the Implicit Grant as described in https://tools.ietf.org/html/rfc6749#section-4.2.
+ *
+ * @param <TAccessToken> The access token type.
+ */
+
+abstract class OAuth2ImplicitGrant(
+    /**
+     * REQUIRED
+     * The client identifier as described in https://tools.ietf.org/html/rfc6749#section-2.2.
+     */
+    var clientId: String = "",
+
+    /**
+     * OPTIONAL
+     * As described in https://tools.ietf.org/html/rfc6749#section-3.1.2.
+     */
+    var redirectUri: String? = null,
+
+    /**
+     * OPTIONAL
+     * The scope of the access request as described in https://tools.ietf.org/html/rfc6749#section-3.3.
+     */
+    var scope: String? = null,
+
+    /**
+     * RECOMMENDED
+     * An opaque value used by the client to maintain
+     * state between the request and callback. The authorization
+     * server includes this value when redirecting the user-agent back
+     * to the client. The parameter SHOULD be used for preventing
+     * cross-site request forgery as described in https://tools.ietf.org/html/rfc6749#section-10.12.
+     */
+    var state: String? = null
+
+) : OAuth2Grant {
+
+    // Constants
+
+    /**
+     * REQUIRED
+     * The "response_type" which MUST be "token".
+     */
+    companion object {
+        @JvmField
+        val RESPONSE_TYPE = "token"
+    }
+}

--- a/library/src/main/java/de/rheinfabrik/heimdall2/coroutines/grants/OAuth2RefreshAccessTokenGrant.kt
+++ b/library/src/main/java/de/rheinfabrik/heimdall2/coroutines/grants/OAuth2RefreshAccessTokenGrant.kt
@@ -1,0 +1,27 @@
+package de.rheinfabrik.heimdall2.coroutines.grants
+
+abstract class OAuth2RefreshAccessTokenGrant(
+    /**
+     * REQUIRED
+     * The "refresh_token" issued to the client.
+     */
+    var refreshToken: String? = null,
+
+    /**
+     * OPTIONAL
+     * The "scope" of the access request as described by here (https://tools.ietf.org/html/rfc6749#section-3.3).
+     */
+    var scope: String? = null
+) :
+    OAuth2Grant {
+    // Constants
+
+    /**
+     * REQUIRED
+     * The OAuth2 "grant_type".
+     */
+    companion object {
+        @JvmField
+        val GRANT_TYPE = "refresh_token"
+    }
+}

--- a/library/src/main/java/de/rheinfabrik/heimdall2/coroutines/grants/OAuth2RefreshAccessTokenGrant.kt
+++ b/library/src/main/java/de/rheinfabrik/heimdall2/coroutines/grants/OAuth2RefreshAccessTokenGrant.kt
@@ -5,7 +5,7 @@ abstract class OAuth2RefreshAccessTokenGrant(
      * REQUIRED
      * The "refresh_token" issued to the client.
      */
-    var refreshToken: String? = null,
+    var refreshToken: String = "",
 
     /**
      * OPTIONAL

--- a/library/src/main/java/de/rheinfabrik/heimdall2/coroutines/grants/OAuth2ResourceOwnerPasswordCredentialsGrant.kt
+++ b/library/src/main/java/de/rheinfabrik/heimdall2/coroutines/grants/OAuth2ResourceOwnerPasswordCredentialsGrant.kt
@@ -1,0 +1,26 @@
+package de.rheinfabrik.heimdall2.coroutines.grants
+
+abstract class OAuth2ResourceOwnerPasswordCredentialsGrant(
+    /**
+     * REQUIRED
+     * The resource owner "username".
+     */
+    var username: String = "",
+
+    /**
+     * REQUIRED
+     * The resource owner "password".
+     */
+    var password: String = "",
+
+    /**
+     * OPTIONAL
+     * The "scope" of the access request as described by here (https://tools.ietf.org/html/rfc6749#section-3.3).
+     */
+    var scope: String? = null
+) : OAuth2Grant {
+
+    companion object {
+        const val GRANT_TYPE = "password"
+    }
+}

--- a/library/src/test/java/de/rheinfabrik/heimdall2/coroutines/OAuth2AccessTokenManagerTest.kt
+++ b/library/src/test/java/de/rheinfabrik/heimdall2/coroutines/OAuth2AccessTokenManagerTest.kt
@@ -1,0 +1,105 @@
+package de.rheinfabrik.heimdall2.coroutines
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import de.rheinfabrik.heimdall2.accesstoken.OAuth2AccessToken
+import de.rheinfabrik.heimdall2.coroutines.grants.OAuth2RefreshAccessTokenGrant
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.*
+
+@ExperimentalCoroutinesApi
+class OAuth2AccessTokenManagerTest {
+
+    @Test
+    fun `when the access token is accessed, and the token is not expired, then the token should be returned`() =
+        runBlockingTest {
+            // given a stored access token
+            val expectedOutcome = mock<OAuth2AccessToken>()
+            val accessTokenStorage = mock<OAuth2AccessTokenStorage>()
+            whenever(accessTokenStorage.getStoredAccessToken()).thenReturn(expectedOutcome)
+
+            // and a refresh access token grant
+            val refreshAccessTokenGrant = mock<OAuth2RefreshAccessTokenGrant>()
+            whenever(refreshAccessTokenGrant.grantNewAccessToken()).thenReturn(null)
+
+            // and a token manager
+            val tokenManager = OAuth2AccessTokenManager(
+                mOAuth2AccessTokenStorage = accessTokenStorage
+            )
+
+            // when the token is accessed
+            val output = tokenManager.getValidAccessToken(
+                refreshAccessTokenGrant = refreshAccessTokenGrant
+            )
+
+            // then the token is received
+            assertEquals(expectedOutcome, output)
+        }
+
+    @Test
+    fun `when the access token is accessed, and the token is expired, then a renewed token should be returned`() =
+        runBlockingTest {
+            // given a stored access token that returns an expired token
+            val expiredToken = mock<OAuth2AccessToken>().apply {
+                whenever(isExpired()).thenReturn(true)
+                whenever(refreshToken).thenReturn("")
+            }
+            val accessTokenStorage = mock<OAuth2AccessTokenStorage>()
+            whenever(accessTokenStorage.getStoredAccessToken()).thenReturn(expiredToken)
+
+            // and a refresh access token grant
+            val expectedOutcome = OAuth2AccessToken(
+                refreshToken = "refresh_token",
+                expirationDate = Calendar.getInstance()
+            )
+            val refreshAccessTokenGrant = mock<OAuth2RefreshAccessTokenGrant>()
+            whenever(refreshAccessTokenGrant.grantNewAccessToken()).thenReturn(expectedOutcome)
+
+            // and a token manager
+            val tokenManager = OAuth2AccessTokenManager(
+                mOAuth2AccessTokenStorage = accessTokenStorage
+            )
+
+            // when the token is retrieved
+            val output = tokenManager.getValidAccessToken(
+                refreshAccessTokenGrant = refreshAccessTokenGrant
+            )
+
+            // then the refreshed token is received
+            assertEquals(expectedOutcome, output)
+        }
+
+    @Test(expected = IllegalStateException::class)
+    fun `when the access token is accessed, and the token is expired and it doesnt have a refresh token, then an exception is returned`() =
+        runBlockingTest {
+            // given a stored access token that returns an expired token
+            val expiredToken = mock<OAuth2AccessToken>().apply {
+                whenever(isExpired()).thenReturn(true)
+            }
+            val accessTokenStorage = mock<OAuth2AccessTokenStorage>()
+            whenever(accessTokenStorage.getStoredAccessToken()).thenReturn(expiredToken)
+
+            // and a refresh access token grant
+            val expectedOutcome = OAuth2AccessToken(
+                refreshToken = "refresh_token",
+                expirationDate = Calendar.getInstance()
+            )
+            val refreshAccessTokenGrant = mock<OAuth2RefreshAccessTokenGrant>()
+            whenever(refreshAccessTokenGrant.grantNewAccessToken()).thenReturn(expectedOutcome)
+
+            // and a token manager
+            val tokenManager = OAuth2AccessTokenManager(
+                mOAuth2AccessTokenStorage = accessTokenStorage
+            )
+
+            // when the token is retrieved
+            val output = tokenManager.getValidAccessToken(
+                refreshAccessTokenGrant = refreshAccessTokenGrant
+            )
+
+            // then the exception is thrown
+        }
+}


### PR DESCRIPTION
### What was done
I created a package called coroutines. This package will contain every class that makes a reference to Kotlin coroutines.

Had to created the grants again with no reference to RxJava and adding the **suspend** keyword in the methods, whenever needed.

![](https://media.giphy.com/media/muHlnG1WU9YfS/giphy.gif)